### PR TITLE
Add fallback logic for cloud type detection in TAF data transformatio…

### DIFF
--- a/src/app/api/weather/route.ts
+++ b/src/app/api/weather/route.ts
@@ -336,6 +336,14 @@ function transformTafData(checkwxData: CheckWXTafResponse): TransformedTafRespon
           if (cloudMatch && cloudMatch[1]) {
             cloudType = cloudMatch[1] as 'CB' | 'TCU';
           }
+        } else {
+          // Fallback: try to find CB/TCU for this cloud coverage code without altitude
+          // This handles cases where altitude isn't parsed but CB/TCU is still in raw TAF
+          const cloudPattern = new RegExp(`\\b${c.code}\\d{3}(CB|TCU)\\b`);
+          const cloudMatch = rawTaf.match(cloudPattern);
+          if (cloudMatch && cloudMatch[1]) {
+            cloudType = cloudMatch[1] as 'CB' | 'TCU';
+          }
         }
         
         // Also check cloud.text for CB/TCU keywords


### PR DESCRIPTION
…n: enhance parsing to identify CB/TCU clouds without altitude information, improving accuracy in weather data processing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a regex-based fallback to identify CB/TCU in TAF clouds when altitude data is missing.
> 
> - **TAF Transformation (`src/app/api/weather/route.ts`)**:
>   - Add fallback regex to detect `CB`/`TCU` for a cloud coverage `code` when altitude is unavailable, using `\b{code}\d{3}(CB|TCU)\b` against `raw_taf`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad422780c0277f22974cbc569d0564bfc8a608bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->