### PR TITLE
Refine HourlyBreakdown component: remove generic 'Opady' from weather…

### DIFF
--- a/src/components/HourlyBreakdown.tsx
+++ b/src/components/HourlyBreakdown.tsx
@@ -139,7 +139,7 @@ function extractPhenomenaBars(hours: HourlyPeriod[]): PhenomenaBar[] {
     'snow': 8,
     'Śnieg': 8,
     'śnieg': 8,
-    'Opady': 8, // "Opady śniegu"
+    // Note: 'Opady' removed - too generic, matches rain/showers incorrectly
     'Rain': 7, // Increased! Rain higher than fog
     'Deszcz': 7,
     'deszcz': 7,
@@ -270,7 +270,7 @@ const getPhenomenaIcon = (label: string, size: string = 'w-4 h-4') => {
   
   // Check for phenomena - order matters! Check more specific first
   if (lower.includes('freez') || lower.includes('marzn')) return <Waves className={`${size} text-cyan-300`} />; // Freezing fog - cyan waves
-  if (lower.includes('snow') || lower.includes('śnieg') || lower.includes('snieg') || lower.includes('opady')) return <Snowflake className={`${size} text-blue-300`} />; // Snow (opady = precipitation)
+  if (lower.includes('snow') || lower.includes('śnieg') || lower.includes('snieg')) return <Snowflake className={`${size} text-blue-300`} />; // Snow
   if (lower.includes('rain') || lower.includes('deszcz')) return <CloudRain className={`${size} text-blue-400`} />;
   if (lower.includes('fog') || lower.includes('mgła')) return <Waves className={`${size} text-slate-400`} />;
   if (lower.includes('mist') || lower.includes('zamgle') || lower.includes('zamglenie')) return <Waves className={`${size} text-slate-400`} />;
@@ -586,7 +586,7 @@ export function HourlyBreakdown({ forecast, language }: HourlyBreakdownProps) {
                           const priorityMap: Record<string, number> = {
                             'Freezing': 10, 'Marznąc': 10, 'FZFG': 10, 'FZRA': 10,
                             'Thunderstorm': 9, 'Burza': 9, 'TS': 9, 'TSRA': 9,
-                            'Snow': 8, 'snow': 8, 'Śnieg': 8, 'śnieg': 8, 'Opady': 8, // Snow higher than fog!
+                            'Snow': 8, 'snow': 8, 'Śnieg': 8, 'śnieg': 8, // Snow higher than fog!
                             'Rain': 7, 'Deszcz': 7, 'deszcz': 7,
                             'Fog': 6, 'Mgła': 6, 'FG': 6,
                             'Mist': 5, 'Zamglenie': 5, 'BR': 5,
@@ -651,7 +651,7 @@ export function HourlyBreakdown({ forecast, language }: HourlyBreakdownProps) {
                 const priorityMap: Record<string, number> = {
                   'Freez': 9, 'Marzn': 9,
                   'Thunder': 8, 'Burz': 8,
-                  'Snow': 8, 'Śnieg': 8, 'Opady': 8,
+                  'Snow': 8, 'Śnieg': 8,
                   'Rain': 7, 'Deszcz': 7,
                   'Fog': 6, 'Mgła': 6,
                   'Mist': 5, 'Zamglenie': 5,
@@ -711,8 +711,8 @@ export function HourlyBreakdown({ forecast, language }: HourlyBreakdownProps) {
                                 
                                 // Check if they're different types (not just "Snow" vs "Light Snow")
                                 const isDifferentType = 
-                                  (first.includes('snow') || first.includes('śnieg') || first.includes('opady')) !==
-                                  (second.includes('snow') || second.includes('śnieg') || second.includes('opady')) ||
+                                  (first.includes('snow') || first.includes('śnieg')) !==
+                                  (second.includes('snow') || second.includes('śnieg')) ||
                                   (first.includes('rain') || first.includes('deszcz')) !==
                                   (second.includes('rain') || second.includes('deszcz')) ||
                                   (first.includes('fog') || first.includes('mgła')) !==

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -1899,7 +1899,7 @@ function extendForecastWithOpenMeteo(
     // Parse Open-Meteo time as UTC and adjust to Warsaw time
     const hourTimeUTC = new Date(openMeteoData.hourly.time[i]);
     const hourTime = adjustToWarsawTime(hourTimeUTC);
-    const hourKey = hourTimeUTC.toISOString().split(':')[0]; // Use UTC for key comparison with TAF
+    const hourKey = hourTime.toISOString().split(':')[0]; // Use Warsaw time for key comparison with TAF
     
     // Only create periods for gaps and within 48h from now
     const hoursFromNow = (hourTime.getTime() - now.getTime()) / (1000 * 60 * 60);


### PR DESCRIPTION
… phenomena handling to improve accuracy in icon representation and priority mapping. Adjust time handling in extendForecastWithOpenMeteo to use Warsaw time for key comparisons, ensuring consistency in forecast data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes generic 'Opady' from phenomena priority/icon handling and switches Open‑Meteo hour key comparisons to Warsaw time for consistent forecast gap filling.
> 
> - **UI (HourlyBreakdown)**
>   - Remove generic `Opady` from phenomena priority maps and icon/type checks to avoid misclassifying rain/showers as snow.
>   - Update `getPhenomenaIcon` and desktop/mobile priority maps; refine second-icon "different type" check accordingly.
> - **Weather Logic (`src/lib/weather.ts`)**
>   - Use Warsaw time (`adjustToWarsawTime`) when building `hourKey` for Open‑Meteo hourly gap filling to align with TAF coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 075b58434712a0ab1724a7a02c0e0594d1fb3666. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->