### PR TITLE
Metar visibility e413b

### DIFF
--- a/src/app/api/weather/test/route.ts
+++ b/src/app/api/weather/test/route.ts
@@ -77,7 +77,7 @@ export async function POST(request: Request) {
         raw_text: testMetarData.data[0].raw_text,
         temp_air: testMetarData.data[0].temperature.celsius,
         temp_dewpoint: testMetarData.data[0].dewpoint.celsius,
-        visibility: testMetarData.data[0].visibility.meters_float,
+        visibility: { meters: testMetarData.data[0].visibility.meters_float },
         visibility_units: 'meters',
         wind: {
           speed_kts: testMetarData.data[0].wind.speed_kts,

--- a/src/app/api/weather/types.ts
+++ b/src/app/api/weather/types.ts
@@ -33,7 +33,7 @@ export interface TransformedMetar {
   raw_text: string;
   temp_air: number;
   temp_dewpoint: number;
-  visibility: number;
+  visibility: { meters: number };
   visibility_units: string;
   wind: Wind;
   ceiling: Ceiling | null;

--- a/src/lib/types/weather.ts
+++ b/src/lib/types/weather.ts
@@ -1,15 +1,18 @@
 // src/lib/types/weather.ts
 
 export interface WindInfo {
-  degrees: number;
+  degrees?: number;      // Legacy field
+  direction?: number;    // Direction in degrees (used by API)
   speed_kts: number;
   gust_kts?: number;
 }
 
 export interface CloudInfo {
   code: string;
-  coverage: 'SKC' | 'FEW' | 'SCT' | 'BKN' | 'OVC';
-  base_feet_agl: number;
+  coverage?: 'SKC' | 'FEW' | 'SCT' | 'BKN' | 'OVC';
+  base_feet_agl: number;  // Can be 0 for SCT000/FEW000 (clouds at ground level)
+  altitude?: number;      // Alternative to base_feet_agl from some APIs
+  cloudType?: 'CB' | 'TCU';  // Cumulonimbus or Towering Cumulus
 }
 
 export interface Visibility {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes METAR visibility to `{ meters }`, adds robust low-visibility parsing/logging, and treats `SCT000/FEW000` as ground-level clouds (ceiling=0) with corresponding risk/impact updates; also passes visibility/wind/ceiling through to UI and loosens wind/cloud types.
> 
> - **API/Parsing (`src/app/api/weather/route.ts`)**:
>   - Normalize visibility to `{ meters }` and update type usage; fallback parsing now recognizes values like `0250` and logs critical low-vis cases.
>   - Detect `SCT000/FEW000` as clouds at ground level; force effective `ceiling: { feet: 0 }` and log accordingly.
> - **Types**:
>   - `TransformedMetar.visibility` changed to `{ meters: number }` (`src/app/api/weather/types.ts`).
>   - Relax `WindInfo` and `CloudInfo` (optional `degrees`/`direction`, allow `base_feet_agl` 0, add `altitude`, `cloudType`) (`src/lib/types/weather.ts`).
> - **Risk/Processing (`src/lib/weather.ts`)**:
>   - Pass through `visibility`, `wind` (prefers `direction` over `degrees`), and `ceiling` to `current` response.
>   - Escalate risk/impacts when `SCT000/FEW000` present; enhance ceiling risk logic for very low FEW/SCT (incl. 0 ft) and retain CB/TCU handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e50baeca00599114a0f29a2efc6891e403630faf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->